### PR TITLE
Improved custom crypto API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ test/dummy/tmp/
 aes_key
 cookie_secret
 *.sqlite3
+.DS_Store

--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,4 @@
-guard :rspec, cmd: "bundle exec rspec" do
+guard :rspec, cmd: "bundle exec rspec", all_after_pass: true do
   require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)
 
@@ -7,5 +7,13 @@ guard :rspec, cmd: "bundle exec rspec" do
   watch(rspec.spec_helper) { rspec.spec_dir }
   watch(rspec.spec_support) { rspec.spec_dir }
   watch(rspec.spec_files)
+  watch("lib/darrrr/provider.rb") {
+    %w(
+      spec/lib/darrrr/account_provider_spec.rb
+      spec/lib/darrrr/recovery_provider_spec.rb
+      spec/lib/integration/account_provider_controller_spec.rb
+      spec/lib/integration/recovery_provider_controller_spec.rb
+    )
+  }
   dsl.watch_spec_files_for(dsl.ruby.lib_files)
 end

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Darrrr.icon_152px = "#{Darrrr.authority}/icon.png"
 Darrrr::AccountProvider.configure do |config|
   config.signing_private_key = ENV["ACCOUNT_PROVIDER_PRIVATE_KEY"]
   config.symmetric_key = ENV["TOKEN_DATA_AES_KEY"]
-  config.tokensign_pubkeys_secp256r1 = [ENV["ACCOUNT_PROVIDER_PUBLIC_KEY"]] || proc { "you wouldn't do this in real life but procs are supported for this value" }
+  config.tokensign_pubkeys_secp256r1 = [ENV["ACCOUNT_PROVIDER_PUBLIC_KEY"]] || lambda { |provider, context| "you wouldn't do this in real life but procs are supported for this value" }
   config.save_token_return = "#{Darrrr.authority}/account-provider/save-token-return"
   config.recover_account_return = "#{Darrrr.authority}/account-provider/recover-account-return"
 end
 
 Darrrr::RecoveryProvider.configure do |config|
   config.signing_private_key = ENV["RECOVERY_PROVIDER_PRIVATE_KEY"]
-  config.countersign_pubkeys_secp256r1 = [ENV["RECOVERY_PROVIDER_PUBLIC_KEY"]] || proc { "you wouldn't do this in real life but procs are supported for this value" }
+  config.countersign_pubkeys_secp256r1 = [ENV["RECOVERY_PROVIDER_PUBLIC_KEY"]] || lambda { |provider, context| "you wouldn't do this in real life but procs are supported for this value" }
   config.token_max_size = 8192
   config.save_token = "#{Darrrr.authority}/recovery-provider/save-token"
   config.recover_account = "#{Darrrr.authority}/recovery-provider/recover-account"
@@ -72,7 +72,7 @@ Set `Darrrr.custom_encryptor = MyCustomEncryptor`
 ```ruby
 Darrrr.with_encryptor(MyCustomEncryptor) do
   # perform DAR actions using MyCustomEncryptor as the crypto provider
-  token = Darrrr.this_account_provider.generate_recovery_token(data: "foo", audience: recovery_provider)
+  recovery_token, sealed_token = Darrrr.this_account_provider.generate_recovery_token(data: "foo", audience: recovery_provider, context: { user: current_user })
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Create a module that responds to `Module.sign`, `Module.verify`, `Module.decrypt
 
 ### Global config
 
-Set `Darrrr.custom_encryptor = MyCustomEncryptor`
+Set `Darrrr.this_account_provider.custom_encryptor = MyCustomEncryptor`
+Set `Darrrr.this_recovery_provider.custom_encryptor = MyCustomEncryptor`
 
 ### On-demand
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Along with a fully featured library, a proof of concept application is provided 
 
 An account provider (e.g. GitHub) is someone who stores a token with someone else (a recovery provider e.g. Facebook) in order to grant access to an account.
 
-In `config/initializers` or any location that is run during application setup, add a file:
+In `config/initializers` or any location that is run during application setup, add a file. **NOTE:** `proc`s are valid values for `countersign_pubkeys_secp256r1` and `tokensign_pubkeys_secp256r1`
 
 ```ruby
 Darrrr.authority = "http://localhost:9292"
@@ -21,14 +21,14 @@ Darrrr.icon_152px = "#{Darrrr.authority}/icon.png"
 Darrrr::AccountProvider.configure do |config|
   config.signing_private_key = ENV["ACCOUNT_PROVIDER_PRIVATE_KEY"]
   config.symmetric_key = ENV["TOKEN_DATA_AES_KEY"]
-  config.tokensign_pubkeys_secp256r1 = [ENV["ACCOUNT_PROVIDER_PUBLIC_KEY"]]
+  config.tokensign_pubkeys_secp256r1 = [ENV["ACCOUNT_PROVIDER_PUBLIC_KEY"]] || proc { "you wouldn't do this in real life but procs are supported for this value" }
   config.save_token_return = "#{Darrrr.authority}/account-provider/save-token-return"
   config.recover_account_return = "#{Darrrr.authority}/account-provider/recover-account-return"
 end
 
 Darrrr::RecoveryProvider.configure do |config|
   config.signing_private_key = ENV["RECOVERY_PROVIDER_PRIVATE_KEY"]
-  config.countersign_pubkeys_secp256r1 = [ENV["RECOVERY_PROVIDER_PUBLIC_KEY"]]
+  config.countersign_pubkeys_secp256r1 = [ENV["RECOVERY_PROVIDER_PUBLIC_KEY"]] || proc { "you wouldn't do this in real life but procs are supported for this value" }
   config.token_max_size = 8192
   config.save_token = "#{Darrrr.authority}/recovery-provider/save-token"
   config.recover_account = "#{Darrrr.authority}/recovery-provider/recover-account"

--- a/config/initializers/delegated_account_recovery.rb
+++ b/config/initializers/delegated_account_recovery.rb
@@ -8,7 +8,7 @@ Darrrr.icon_152px = "#{Darrrr.authority}/icon.png"
 Darrrr::AccountProvider.configure do |config|
   config.signing_private_key = ENV["ACCOUNT_PROVIDER_PRIVATE_KEY"]
   config.symmetric_key = ENV["TOKEN_DATA_AES_KEY"]
-  config.tokensign_pubkeys_secp256r1 = lambda do |account_provider|
+  config.tokensign_pubkeys_secp256r1 = lambda do |account_provider, context|
     [ENV["ACCOUNT_PROVIDER_PUBLIC_KEY"]]
   end
   config.save_token_return = "#{Darrrr.authority}/account-provider/save-token-return"
@@ -17,7 +17,7 @@ end
 
 Darrrr::RecoveryProvider.configure do |config|
   config.signing_private_key = ENV["RECOVERY_PROVIDER_PRIVATE_KEY"]
-  config.countersign_pubkeys_secp256r1 = lambda do |recovery_provider|
+  config.countersign_pubkeys_secp256r1 = lambda do |recovery_provider, context|
     [ENV["RECOVERY_PROVIDER_PUBLIC_KEY"]]
   end
   config.token_max_size = 8192

--- a/config/initializers/delegated_account_recovery.rb
+++ b/config/initializers/delegated_account_recovery.rb
@@ -8,14 +8,18 @@ Darrrr.icon_152px = "#{Darrrr.authority}/icon.png"
 Darrrr::AccountProvider.configure do |config|
   config.signing_private_key = ENV["ACCOUNT_PROVIDER_PRIVATE_KEY"]
   config.symmetric_key = ENV["TOKEN_DATA_AES_KEY"]
-  config.tokensign_pubkeys_secp256r1 = [ENV["ACCOUNT_PROVIDER_PUBLIC_KEY"]]
+  config.tokensign_pubkeys_secp256r1 = lambda do |account_provider|
+    [ENV["ACCOUNT_PROVIDER_PUBLIC_KEY"]]
+  end
   config.save_token_return = "#{Darrrr.authority}/account-provider/save-token-return"
   config.recover_account_return = "#{Darrrr.authority}/account-provider/recover-account-return"
 end
 
 Darrrr::RecoveryProvider.configure do |config|
   config.signing_private_key = ENV["RECOVERY_PROVIDER_PRIVATE_KEY"]
-  config.countersign_pubkeys_secp256r1 = [ENV["RECOVERY_PROVIDER_PUBLIC_KEY"]]
+  config.countersign_pubkeys_secp256r1 = lambda do |recovery_provider|
+    [ENV["RECOVERY_PROVIDER_PUBLIC_KEY"]]
+  end
   config.token_max_size = 8192
   config.save_token = "#{Darrrr.authority}/recovery-provider/save-token"
   config.recover_account = "#{Darrrr.authority}/recovery-provider/recover-account"

--- a/config/initializers/delegated_account_recovery.rb
+++ b/config/initializers/delegated_account_recovery.rb
@@ -8,7 +8,7 @@ Darrrr.icon_152px = "#{Darrrr.authority}/icon.png"
 Darrrr::AccountProvider.configure do |config|
   config.signing_private_key = ENV["ACCOUNT_PROVIDER_PRIVATE_KEY"]
   config.symmetric_key = ENV["TOKEN_DATA_AES_KEY"]
-  config.tokensign_pubkeys_secp256r1 = lambda do |account_provider, context|
+  config.tokensign_pubkeys_secp256r1 = lambda do |context|
     [ENV["ACCOUNT_PROVIDER_PUBLIC_KEY"]]
   end
   config.save_token_return = "#{Darrrr.authority}/account-provider/save-token-return"
@@ -17,7 +17,7 @@ end
 
 Darrrr::RecoveryProvider.configure do |config|
   config.signing_private_key = ENV["RECOVERY_PROVIDER_PRIVATE_KEY"]
-  config.countersign_pubkeys_secp256r1 = lambda do |recovery_provider, context|
+  config.countersign_pubkeys_secp256r1 = lambda do |context|
     [ENV["RECOVERY_PROVIDER_PUBLIC_KEY"]]
   end
   config.token_max_size = 8192

--- a/controllers/account_provider_controller.rb
+++ b/controllers/account_provider_controller.rb
@@ -6,7 +6,7 @@ class AccountProviderController < MainController
 
   post "/create" do
     recovery_provider = Darrrr.recovery_provider(params["recovery_provider"])
-    token = Darrrr.this_account_provider.generate_recovery_token(data: params["phrase"], audience: recovery_provider)
+    token, sealed_token = Darrrr.this_account_provider.generate_recovery_token(data: params["phrase"], audience: recovery_provider)
 
     ReferenceToken.create({
       provider: recovery_provider.origin,
@@ -19,7 +19,7 @@ class AccountProviderController < MainController
     erb :recovery_post, locals: {
       state: token.state_url,
       endpoint: recovery_provider.save_token,
-      payload: Darrrr.this_account_provider.seal(token),
+      payload: sealed_token,
       token: token, # just for debugging
     }
   end

--- a/darrrr.gemspec
+++ b/darrrr.gemspec
@@ -1,9 +1,8 @@
 # coding: utf-8
-require_relative "lib/darrrr/version"
 
 Gem::Specification.new do |gem|
   gem.name    = "darrrr"
-  gem.version = Darrrr::VERSION
+  gem.version = "0.0.3"
 
   gem.summary = "Client library for the Delegated Recovery spec"
   gem.description = "See https://www.facebook.com/notes/protect-the-graph/improving-account-security-with-delegated-recovery/1833022090271267/"

--- a/darrrr.gemspec
+++ b/darrrr.gemspec
@@ -3,6 +3,7 @@
 Gem::Specification.new do |gem|
   gem.name    = "darrrr"
   gem.version = "0.0.3"
+  gem.licenses = ['MIT']
 
   gem.summary = "Client library for the Delegated Recovery spec"
   gem.description = "See https://www.facebook.com/notes/protect-the-graph/improving-account-security-with-delegated-recovery/1833022090271267/"

--- a/lib/darrrr.rb
+++ b/lib/darrrr.rb
@@ -69,7 +69,10 @@ module Darrrr
       unless self.recovery_providers
         raise "No recovery providers configured"
       end
-      if self.recovery_providers.include?(provider_origin)
+
+      if provider_origin == this_recovery_provider.origin
+        this_recovery_provider
+      elsif self.recovery_providers.include?(provider_origin)
         RecoveryProvider.new(provider_origin).load
       else
         raise UnknownProviderError, "Unknown recovery provider: #{provider_origin}"
@@ -92,7 +95,9 @@ module Darrrr
       unless self.account_providers
         raise "No account providers configured"
       end
-      if self.account_providers.include?(provider_origin)
+      if provider_origin == this_account_provider.origin
+        this_account_provider
+      elsif self.account_providers.include?(provider_origin)
         AccountProvider.new(provider_origin).load
       else
         raise UnknownProviderError, "Unknown account provider: #{provider_origin}"

--- a/lib/darrrr.rb
+++ b/lib/darrrr.rb
@@ -56,7 +56,6 @@ module Darrrr
   include Constants
 
   class << self
-    REQUIRED_CRYPTO_OPS = [:sign, :verify, :encrypt, :decrypt].freeze
     # recovery provider data is only loaded (and cached) upon use.
     attr_accessor :recovery_providers, :account_providers, :cache, :allow_unsafe_urls,
       :privacy_policy, :icon_152px, :authority
@@ -147,39 +146,6 @@ module Darrrr
     # returns the account provider information in hash form
     def recovery_provider_config
       this_recovery_provider.to_h
-    end
-
-    def with_encryptor(encryptor)
-      raise ArgumentError, "A block must be supplied" unless block_given?
-      unless valid_encryptor?(encryptor)
-        raise ArgumentError, "custom encryption class must respond to all of #{REQUIRED_CRYPTO_OPS}"
-      end
-
-      Thread.current[:darrrr_encryptor] = encryptor
-      yield
-    ensure
-      Thread.current[:darrrr_encryptor] = nil
-    end
-
-    # Returns the crypto API to be used. A thread local instance overrides the
-    # globally configured value which overrides the default encryptor.
-    def encryptor
-      Thread.current[:darrrr_encryptor] || @encryptor || DefaultEncryptor
-    end
-
-    # Overrides the global `encryptor` API to use
-    #
-    # encryptor: a class/module that responds to all +REQUIRED_CRYPTO_OPS+.
-    def custom_encryptor=(encryptor)
-      if valid_encryptor?(encryptor)
-        @encryptor = encryptor
-      else
-        raise ArgumentError, "custom encryption class must respond to all of #{REQUIRED_CRYPTO_OPS}"
-      end
-    end
-
-    private def valid_encryptor?(encryptor)
-      REQUIRED_CRYPTO_OPS.all? {|m| encryptor.respond_to?(m)}
     end
   end
 end

--- a/lib/darrrr.rb
+++ b/lib/darrrr.rb
@@ -19,24 +19,25 @@ require_relative "darrrr/cryptors/default/encrypted_data"
 require_relative "darrrr/cryptors/default/encrypted_data_io"
 
 module Darrrr
+  class DelegatedRecoveryError < StandardError; end
   # Represents a binary serialization error
-  class RecoveryTokenSerializationError < StandardError; end
+  class RecoveryTokenSerializationError < DelegatedRecoveryError; end
 
   # Represents invalid data within a valid token
   #  (e.g. wrong `version` number, invalid token `type`)
-  class TokenFormatError < StandardError; end
+  class TokenFormatError < DelegatedRecoveryError; end
 
   # Represents all crypto errors
   #   (e.g. invalid keys, invalid signature, decrypt failures)
-  class CryptoError < StandardError; end
+  class CryptoError < DelegatedRecoveryError; end
 
   # Represents providers supplying invalid configurations
   #  (e.g. non-https URLs, missing required fields, http errors)
-  class ProviderConfigError < StandardError; end
+  class ProviderConfigError < DelegatedRecoveryError; end
 
   # Represents an invalid countersigned recovery token.
   #  (e.g. invalid signature, invalid nested token, unregistered provider, stale tokens)
-  class CountersignedTokenError < StandardError
+  class CountersignedTokenError < DelegatedRecoveryError
     attr_reader :key
     def initialize(message, key)
       super(message)
@@ -46,11 +47,11 @@ module Darrrr
 
   # Represents an invalid recovery token.
   #  (e.g. invalid signature, unregistered provider, stale tokens)
-  class RecoveryTokenError < StandardError; end
+  class RecoveryTokenError < DelegatedRecoveryError; end
 
   # Represents a call to to `recovery_provider` or `account_provider` that
   # has not been registered.
-  class UnknownProviderError < ArgumentError; end
+  class UnknownProviderError < DelegatedRecoveryError; end
 
   include Constants
 

--- a/lib/darrrr/account_provider.rb
+++ b/lib/darrrr/account_provider.rb
@@ -30,7 +30,7 @@ module Darrrr
     # passing `self` as the first argument.
     def unseal_keys(context = nil)
       if @tokensign_pubkeys_secp256r1.respond_to?(:call)
-        @tokensign_pubkeys_secp256r1.call(self, context)
+        @tokensign_pubkeys_secp256r1.call(context)
       else
         @tokensign_pubkeys_secp256r1
       end

--- a/lib/darrrr/account_provider.rb
+++ b/lib/darrrr/account_provider.rb
@@ -117,11 +117,7 @@ module Darrrr
       # TODO not required, to be implemented later
 
       # 9. Decrypt the data field from the original recovery token and parse its information, if present.
-      begin
-        recovery_token.decode
-      rescue CryptoError
-        raise CountersignedTokenError.new("Recovery token data could not be decrypted", :indecipherable_opaque_data)
-      end
+      # no decryption here is attempted. Attempts to call `decode` will just fail.
 
       # 10. Apply any additional processing which provider-specific data in the opaque data portion may indicate is necessary.
       begin

--- a/lib/darrrr/account_provider.rb
+++ b/lib/darrrr/account_provider.rb
@@ -55,7 +55,7 @@ module Darrrr
     #   provide some assurance the same browser was used.
     def generate_recovery_token(data:, audience:)
       RecoveryToken.build(issuer: self, audience: audience, type: RECOVERY_TOKEN_TYPE).tap do |token|
-        token.data = Darrrr.encryptor.encrypt(data)
+        token.data = Darrrr.encryptor.encrypt(data, self)
       end
     end
 

--- a/lib/darrrr/account_provider.rb
+++ b/lib/darrrr/account_provider.rb
@@ -85,7 +85,7 @@ module Darrrr
     #
     # returns a verified recovery token or raises
     # an error if the token fails validation.
-    def validate_countersigned_recovery_token!(countersigned_token, context = nil)
+    def validate_countersigned_recovery_token!(countersigned_token, context = {})
       # 5. Validate the the issuer field is present in the token,
       # and that it matches the audience field in the original countersigned token.
       begin

--- a/lib/darrrr/account_provider.rb
+++ b/lib/darrrr/account_provider.rb
@@ -57,7 +57,7 @@ module Darrrr
     # returns a [RecoveryToken, b64 encoded sealed_token] tuple
     def generate_recovery_token(data:, audience:, context: nil)
       token = RecoveryToken.build(issuer: self, audience: audience, type: RECOVERY_TOKEN_TYPE)
-      token.data = Darrrr.encryptor.encrypt(data, self, context)
+      token.data = self.encryptor.encrypt(data, self, context)
 
       [token, seal(token, context)]
     end
@@ -68,6 +68,10 @@ module Darrrr
     def dangerous_unverified_recovery_token(countersigned_token)
       parsed_countersigned_token = RecoveryToken.parse(Base64.strict_decode64(countersigned_token))
       RecoveryToken.parse(parsed_countersigned_token.data)
+    end
+
+    def encryptor_key
+      :darrrr_account_provider_encryptor
     end
 
     # Validates the countersigned recovery token by verifying the signature

--- a/lib/darrrr/account_provider.rb
+++ b/lib/darrrr/account_provider.rb
@@ -55,7 +55,7 @@ module Darrrr
     #   provide some assurance the same browser was used.
     def generate_recovery_token(data:, audience:)
       RecoveryToken.build(issuer: self, audience: audience, type: RECOVERY_TOKEN_TYPE).tap do |token|
-        token.data = Darrrr.encryptor.encrypt(data, self)
+        token.data = Darrrr.encryptor.encrypt(data)
       end
     end
 

--- a/lib/darrrr/crypto_helper.rb
+++ b/lib/darrrr/crypto_helper.rb
@@ -34,7 +34,7 @@ module Darrrr
       end
 
       token_data, signature = partition_signed_token(token_and_signature, token)
-      self.unseal_keys.each do |key|
+      self.unseal_keys(context).each do |key|
         return token if Darrrr.encryptor.verify(token_data, signature, key, self, context)
       end
       raise CryptoError, "Recovery token signature was invalid"

--- a/lib/darrrr/crypto_helper.rb
+++ b/lib/darrrr/crypto_helper.rb
@@ -12,7 +12,7 @@ module Darrrr
     def seal(token, context = nil)
       raise RuntimeError, "signing private key must be set" unless self.instance_variable_get(:@signing_private_key)
       binary_token = token.to_binary_s
-      signature = Darrrr.encryptor.sign(binary_token, self.instance_variable_get(:@signing_private_key), self, context)
+      signature = self.encryptor.sign(binary_token, self.instance_variable_get(:@signing_private_key), self, context)
       Base64.strict_encode64([binary_token, signature].join)
     end
 
@@ -35,7 +35,7 @@ module Darrrr
 
       token_data, signature = partition_signed_token(token_and_signature, token)
       self.unseal_keys(context).each do |key|
-        return token if Darrrr.encryptor.verify(token_data, signature, key, self, context)
+        return token if self.encryptor.verify(token_data, signature, key, self, context)
       end
       raise CryptoError, "Recovery token signature was invalid"
     end

--- a/lib/darrrr/crypto_helper.rb
+++ b/lib/darrrr/crypto_helper.rb
@@ -10,9 +10,9 @@ module Darrrr
     # returns a base64 value for the binary token string and the signature
     # of the token.
     def seal(token)
-      raise RuntimeError, "signing private key must be set" unless self.signing_private_key
+      raise RuntimeError, "signing private key must be set" unless self.instance_variable_get(:@signing_private_key)
       binary_token = token.to_binary_s
-      signature = Darrrr.encryptor.sign(binary_token, self.signing_private_key)
+      signature = Darrrr.encryptor.sign(binary_token, self.instance_variable_get(:@signing_private_key))
       Base64.strict_encode64([binary_token, signature].join)
     end
 

--- a/lib/darrrr/crypto_helper.rb
+++ b/lib/darrrr/crypto_helper.rb
@@ -12,7 +12,7 @@ module Darrrr
     def seal(token)
       raise RuntimeError, "signing private key must be set" unless self.instance_variable_get(:@signing_private_key)
       binary_token = token.to_binary_s
-      signature = Darrrr.encryptor.sign(binary_token, self.instance_variable_get(:@signing_private_key))
+      signature = Darrrr.encryptor.sign(binary_token, self.instance_variable_get(:@signing_private_key), self)
       Base64.strict_encode64([binary_token, signature].join)
     end
 
@@ -35,7 +35,7 @@ module Darrrr
 
       token_data, signature = partition_signed_token(token_and_signature, token)
       self.unseal_keys.each do |key|
-        return token if Darrrr.encryptor.verify(token_data, signature, key)
+        return token if Darrrr.encryptor.verify(token_data, signature, key, self)
       end
       raise CryptoError, "Recovery token signature was invalid"
     end

--- a/lib/darrrr/crypto_helper.rb
+++ b/lib/darrrr/crypto_helper.rb
@@ -12,7 +12,7 @@ module Darrrr
     def seal(token)
       raise RuntimeError, "signing private key must be set" unless self.instance_variable_get(:@signing_private_key)
       binary_token = token.to_binary_s
-      signature = Darrrr.encryptor.sign(binary_token, self.instance_variable_get(:@signing_private_key), self)
+      signature = Darrrr.encryptor.sign(binary_token, self.instance_variable_get(:@signing_private_key))
       Base64.strict_encode64([binary_token, signature].join)
     end
 
@@ -35,7 +35,7 @@ module Darrrr
 
       token_data, signature = partition_signed_token(token_and_signature, token)
       self.unseal_keys.each do |key|
-        return token if Darrrr.encryptor.verify(token_data, signature, key, self)
+        return token if Darrrr.encryptor.verify(token_data, signature, key)
       end
       raise CryptoError, "Recovery token signature was invalid"
     end

--- a/lib/darrrr/cryptors/default/default_encryptor.rb
+++ b/lib/darrrr/cryptors/default/default_encryptor.rb
@@ -6,20 +6,18 @@ module Darrrr
       # Encrypts the data in an opaque way
       #
       # data: the secret to be encrypted
-      # provider: the account provider performing the encryption
       #
       # returns a byte array representation of the data
-      def encrypt(data, _provider)
+      def encrypt(data)
         EncryptedData.build(data).to_binary_s
       end
 
       # Decrypts the data
       #
       # ciphertext: the byte array to be decrypted
-      # provider: the account provider performing the decryption
       #
       # returns a string
-      def decrypt(ciphertext, _provider)
+      def decrypt(ciphertext)
         EncryptedData.parse(ciphertext).decrypt
       end
 
@@ -27,10 +25,9 @@ module Darrrr
       # payload: binary serialized recovery token (to_binary_s).
       #
       # key: the private EC key used to sign the token
-      # provider: the account/recovery provider performing the signature
       #
       # returns signature in ASN.1 DER r + s sequence
-      def sign(payload, key, _provider)
+      def sign(payload, key)
         digest = DIGEST.new.digest(payload)
         ec = OpenSSL::PKey::EC.new(Base64.strict_decode64(key))
         ec.dsa_sign_asn1(digest)
@@ -39,10 +36,9 @@ module Darrrr
       # payload: token in binary form
       # signature: signature of the binary token
       # key: the EC public key used to verify the signature
-      # provider: the account/recovery provider verifying the signature
       #
       # returns true if signature validates the payload
-      def verify(payload, signature, key, _provider)
+      def verify(payload, signature, key)
         public_key_hex = format_key(key)
         pkey = OpenSSL::PKey::EC.new(GROUP)
         public_key_bn = OpenSSL::BN.new(public_key_hex, 16)

--- a/lib/darrrr/cryptors/default/default_encryptor.rb
+++ b/lib/darrrr/cryptors/default/default_encryptor.rb
@@ -6,18 +6,20 @@ module Darrrr
       # Encrypts the data in an opaque way
       #
       # data: the secret to be encrypted
+      # context: arbitrary data originally passed in via Provider#seal
       #
       # returns a byte array representation of the data
-      def encrypt(data)
+      def encrypt(data, _provider, _context = nil)
         EncryptedData.build(data).to_binary_s
       end
 
       # Decrypts the data
       #
       # ciphertext: the byte array to be decrypted
+      # context: arbitrary data originally passed in via RecoveryToken#decode
       #
       # returns a string
-      def decrypt(ciphertext)
+      def decrypt(ciphertext, _provider, _context = nil)
         EncryptedData.parse(ciphertext).decrypt
       end
 
@@ -25,9 +27,10 @@ module Darrrr
       # payload: binary serialized recovery token (to_binary_s).
       #
       # key: the private EC key used to sign the token
+      # context: arbitrary data originally passed in via Provider#seal
       #
       # returns signature in ASN.1 DER r + s sequence
-      def sign(payload, key)
+      def sign(payload, key, _provider, context = nil)
         digest = DIGEST.new.digest(payload)
         ec = OpenSSL::PKey::EC.new(Base64.strict_decode64(key))
         ec.dsa_sign_asn1(digest)
@@ -36,9 +39,10 @@ module Darrrr
       # payload: token in binary form
       # signature: signature of the binary token
       # key: the EC public key used to verify the signature
+      # context: arbitrary data originally passed in via #unseal
       #
       # returns true if signature validates the payload
-      def verify(payload, signature, key)
+      def verify(payload, signature, key, _provider, _context = nil)
         public_key_hex = format_key(key)
         pkey = OpenSSL::PKey::EC.new(GROUP)
         public_key_bn = OpenSSL::BN.new(public_key_hex, 16)

--- a/lib/darrrr/cryptors/default/default_encryptor.rb
+++ b/lib/darrrr/cryptors/default/default_encryptor.rb
@@ -6,18 +6,20 @@ module Darrrr
       # Encrypts the data in an opaque way
       #
       # data: the secret to be encrypted
+      # provider: the account provider performing the encryption
       #
       # returns a byte array representation of the data
-      def encrypt(data)
+      def encrypt(data, _provider)
         EncryptedData.build(data).to_binary_s
       end
 
       # Decrypts the data
       #
       # ciphertext: the byte array to be decrypted
+      # provider: the account provider performing the decryption
       #
       # returns a string
-      def decrypt(ciphertext)
+      def decrypt(ciphertext, _provider)
         EncryptedData.parse(ciphertext).decrypt
       end
 
@@ -25,9 +27,10 @@ module Darrrr
       # payload: binary serialized recovery token (to_binary_s).
       #
       # key: the private EC key used to sign the token
+      # provider: the account/recovery provider performing the signature
       #
       # returns signature in ASN.1 DER r + s sequence
-      def sign(payload, key)
+      def sign(payload, key, _provider)
         digest = DIGEST.new.digest(payload)
         ec = OpenSSL::PKey::EC.new(Base64.strict_decode64(key))
         ec.dsa_sign_asn1(digest)
@@ -36,9 +39,10 @@ module Darrrr
       # payload: token in binary form
       # signature: signature of the binary token
       # key: the EC public key used to verify the signature
+      # provider: the account/recovery provider verifying the signature
       #
       # returns true if signature validates the payload
-      def verify(payload, signature, key)
+      def verify(payload, signature, key, _provider)
         public_key_hex = format_key(key)
         pkey = OpenSSL::PKey::EC.new(GROUP)
         public_key_bn = OpenSSL::BN.new(public_key_hex, 16)

--- a/lib/darrrr/cryptors/default/encrypted_data.rb
+++ b/lib/darrrr/cryptors/default/encrypted_data.rb
@@ -19,9 +19,9 @@ module Darrrr
     # token_object: an EncryptedDataIO instance
     # instance.
     def initialize(token_object)
-      raise ArgumentError, "Version must be #{PROTOCOL_VERSION}. Supplied: #{token_object.version}" unless token_object.version == CIPHER_VERSION
-      raise ArgumentError, "Auth Tag must be 16 bytes" unless token_object.auth_tag.length == AUTH_TAG_LENGTH
-      raise ArgumentError, "IV must be 12 bytes" unless token_object.iv.length == IV_LENGTH
+      raise TokenFormatError, "Version must be #{PROTOCOL_VERSION}. Supplied: #{token_object.version}" unless token_object.version == CIPHER_VERSION
+      raise TokenFormatError, "Auth Tag must be 16 bytes" unless token_object.auth_tag.length == AUTH_TAG_LENGTH
+      raise TokenFormatError, "IV must be 12 bytes" unless token_object.iv.length == IV_LENGTH
       @token_object = token_object
     end
     private_class_method :new

--- a/lib/darrrr/cryptors/default/encrypted_data.rb
+++ b/lib/darrrr/cryptors/default/encrypted_data.rb
@@ -82,7 +82,7 @@ module Darrrr
 
         OpenSSL::Cipher.new(EncryptedData::CIPHER).tap do |cipher|
           cipher.send(mode)
-          cipher.key = [Darrrr.this_account_provider.symmetric_key].pack("H*")
+          cipher.key = [Darrrr.this_account_provider.instance_variable_get(:@symmetric_key)].pack("H*")
         end
       end
     end

--- a/lib/darrrr/recovery_provider.rb
+++ b/lib/darrrr/recovery_provider.rb
@@ -42,9 +42,9 @@ module Darrrr
     #
     # returns the value of `countersign_pubkeys_secp256r1` or executes a proc
     # passing `self` as the first argument.
-    def unseal_keys
+    def unseal_keys(context = nil)
       if @countersign_pubkeys_secp256r1.respond_to?(:call)
-        @countersign_pubkeys_secp256r1.call(self)
+        @countersign_pubkeys_secp256r1.call(self, context)
       else
         @countersign_pubkeys_secp256r1
       end
@@ -65,7 +65,7 @@ module Darrrr
     #
     # returns a Base64 encoded representation of the countersigned token
     # and the signature over the token.
-    def countersign_token(token)
+    def countersign_token(token, context = nil)
       begin
         account_provider = RecoveryToken.account_provider_issuer(token)
       rescue RecoveryTokenSerializationError, UnknownProviderError
@@ -79,14 +79,14 @@ module Darrrr
       )
 
       counter_recovery_token.data = token
-      seal(counter_recovery_token)
+      seal(counter_recovery_token, context)
     end
 
     # Validate the token according to the processing instructions for the
     # save-token endpoint.
     #
     # Returns a validated token
-    def validate_recovery_token!(token)
+    def validate_recovery_token!(token, context = nil)
       errors = []
 
       # 1. Authenticate the User. The exact nature of how the Recovery Provider authenticates the User is beyond the scope of this specification.
@@ -103,7 +103,7 @@ module Darrrr
       # 3. Validate that the version value is 0.
       # 5. Validate the signature over the token according to processing rules for the algorithm implied by the version.
       begin
-        recovery_token = account_provider.unseal(token)
+        recovery_token = account_provider.unseal(token, context)
       rescue CryptoError => e
         raise RecoveryTokenError.new("Unable to verify signature of token")
       rescue TokenFormatError => e

--- a/lib/darrrr/recovery_provider.rb
+++ b/lib/darrrr/recovery_provider.rb
@@ -90,7 +90,7 @@ module Darrrr
     # save-token endpoint.
     #
     # Returns a validated token
-    def validate_recovery_token!(token, context = nil)
+    def validate_recovery_token!(token, context = {})
       errors = []
 
       # 1. Authenticate the User. The exact nature of how the Recovery Provider authenticates the User is beyond the scope of this specification.

--- a/lib/darrrr/recovery_provider.rb
+++ b/lib/darrrr/recovery_provider.rb
@@ -57,6 +57,10 @@ module Darrrr
       [self.recover_account, "?token_id=", URI.escape(token_id)].join
     end
 
+    def encryptor_key
+      :darrrr_recovery_provider_encryptor
+    end
+
     # Takes a binary representation of a token and signs if for a given
     # account provider. Do not pass in a RecoveryToken object. The wrapping
     # data structure is identical to the structure it's wrapping in format.

--- a/lib/darrrr/recovery_provider.rb
+++ b/lib/darrrr/recovery_provider.rb
@@ -44,7 +44,7 @@ module Darrrr
     # passing `self` as the first argument.
     def unseal_keys(context = nil)
       if @countersign_pubkeys_secp256r1.respond_to?(:call)
-        @countersign_pubkeys_secp256r1.call(self, context)
+        @countersign_pubkeys_secp256r1.call(context)
       else
         @countersign_pubkeys_secp256r1
       end

--- a/lib/darrrr/recovery_token.rb
+++ b/lib/darrrr/recovery_token.rb
@@ -24,7 +24,7 @@ module Darrrr
     private_class_method :new
 
     def decode(context = nil)
-      Darrrr.encryptor.decrypt(self.data, Darrrr.this_account_provider, context)
+      Darrrr.this_account_provider.encryptor.decrypt(self.data, Darrrr.this_account_provider, context)
     end
 
     # A globally known location of the token, used to initiate a recovery

--- a/lib/darrrr/recovery_token.rb
+++ b/lib/darrrr/recovery_token.rb
@@ -2,7 +2,7 @@
 
 # Handles binary serialization/deserialization of recovery token data. It does
 # not manage signing/verification of tokens.
-
+# Only account providers will ever call the decode function
 module Darrrr
   class RecoveryToken
     extend Forwardable
@@ -23,8 +23,8 @@ module Darrrr
     end
     private_class_method :new
 
-    def decode
-      Darrrr.encryptor.decrypt(self.data)
+    def decode(context = nil)
+      Darrrr.encryptor.decrypt(self.data, Darrrr.this_account_provider, context)
     end
 
     # A globally known location of the token, used to initiate a recovery

--- a/lib/darrrr/recovery_token.rb
+++ b/lib/darrrr/recovery_token.rb
@@ -24,7 +24,7 @@ module Darrrr
     private_class_method :new
 
     def decode
-      Darrrr.encryptor.decrypt(self.data, Darrrr.account_provider(self.issuer))
+      Darrrr.encryptor.decrypt(self.data)
     end
 
     # A globally known location of the token, used to initiate a recovery

--- a/lib/darrrr/recovery_token.rb
+++ b/lib/darrrr/recovery_token.rb
@@ -24,7 +24,7 @@ module Darrrr
     private_class_method :new
 
     def decode
-      Darrrr.encryptor.decrypt(self.data)
+      Darrrr.encryptor.decrypt(self.data, Darrrr.account_provider(self.issuer))
     end
 
     # A globally known location of the token, used to initiate a recovery

--- a/lib/darrrr/recovery_token.rb
+++ b/lib/darrrr/recovery_token.rb
@@ -41,7 +41,7 @@ module Darrrr
       # returns a RecoveryToken.
       def build(issuer:, audience:, type:)
         token = RecoveryTokenWriter.new.tap do |token|
-          token.token_id = SecureRandom.random_bytes(16).bytes.to_a
+          token.token_id = token_id
           token.issuer = issuer.origin
           token.issued_time = Time.now.utc.iso8601
           token.options = 0 # when the token-status endpoint is implemented, change this to 1
@@ -50,6 +50,12 @@ module Darrrr
           token.token_type = type
         end
         new(token)
+      end
+
+      # token ID generates a random array of bytes.
+      # this method only exists so that it can be stubbed.
+      def token_id
+        SecureRandom.random_bytes(16).bytes.to_a
       end
 
       # serialized_data: a binary string representation of a RecoveryToken.

--- a/lib/darrrr/version.rb
+++ b/lib/darrrr/version.rb
@@ -1,3 +1,0 @@
-module Darrrr
-  VERSION = "0.0.3"
-end

--- a/spec/lib/darrrr/account_provider_spec.rb
+++ b/spec/lib/darrrr/account_provider_spec.rb
@@ -180,9 +180,10 @@ module Darrrr
       payload = Base64.strict_decode64(account_provider.seal(token))
       countersigned_token = recovery_provider.seal(raw_token(data: payload))
 
+      validated_token = account_provider.validate_countersigned_recovery_token!(countersigned_token)
       expect {
-        account_provider.validate_countersigned_recovery_token!(countersigned_token)
-      }.to raise_error(CountersignedTokenError, /Recovery token data could not be decrypted/)
+        validated_token.decode
+      }.to raise_error(CryptoError, /Unable to decrypt data/)
     end
   end
 end

--- a/spec/lib/darrrr/account_provider_spec.rb
+++ b/spec/lib/darrrr/account_provider_spec.rb
@@ -6,7 +6,7 @@ module Darrrr
   describe AccountProvider, vcr: { :cassette_name => "delegated_account_recovery/recovery_provider" } do
     let(:recovery_provider) { example_recovery_provider }
     let(:account_provider) { AccountProvider.this }
-    let(:token) { account_provider.generate_recovery_token(data: "hai", audience: recovery_provider) }
+    let(:token) { account_provider.generate_recovery_token(data: "hai", audience: recovery_provider).first }
 
     # Generate a random key that isn't used during the sealing process.
     # openssl ecparam -name prime256v1 -genkey -noout -out prime256v1-key.pem
@@ -23,12 +23,12 @@ module Darrrr
         token.audience = account_provider.origin
         token.token_type = COUNTERSIGNED_RECOVERY_TOKEN_TYPE
         token.version = version || PROTOCOL_VERSION
-        token.data = data || Base64.strict_decode64(account_provider.seal(recovery_token))
+        token.data = data || Base64.strict_decode64(account_provider.send(:seal, recovery_token))
       end
     end
 
     it "tokens can be sealed and unsealed" do
-      payload = Base64.strict_decode64(account_provider.seal(token))
+      payload = Base64.strict_decode64(account_provider.send(:seal, token))
       unsealed_token = account_provider.unseal(payload)
       expect(token.token_object).to eq(unsealed_token.token_object)
       expect("hai").to eq(unsealed_token.decode)
@@ -38,7 +38,7 @@ module Darrrr
       expect(account_provider).to receive(:unseal_keys).and_return(
         [account_provider.unseal_keys[0], unused_unseal_key]
       ).at_least(:once)
-      payload = Base64.strict_decode64(account_provider.seal(token))
+      payload = Base64.strict_decode64(account_provider.send(:seal, token))
       unsealed_token = account_provider.unseal(payload)
       expect(token.token_object).to eq(unsealed_token.token_object)
       expect("hai").to eq(unsealed_token.decode)
@@ -50,7 +50,7 @@ module Darrrr
         [unused_unseal_key, account_provider.unseal_keys[0]]
       ).at_least(:once)
 
-      payload = Base64.strict_decode64(account_provider.seal(token))
+      payload = Base64.strict_decode64(account_provider.send(:seal, token))
       unsealed_token = account_provider.unseal(payload)
       expect(token.token_object).to eq(unsealed_token.token_object)
       expect("hai").to eq(unsealed_token.decode)
@@ -60,13 +60,13 @@ module Darrrr
       expect(account_provider).to receive(:unseal_keys).and_return(
         [unused_unseal_key]
       )
-      payload = Base64.strict_decode64(account_provider.seal(token))
+      payload = Base64.strict_decode64(account_provider.send(:seal, token))
       expect { account_provider.unseal(payload) }.to raise_error(CryptoError)
     end
 
     it "invalid signatures raise errors" do
       # mess with the signature
-      payload = Base64.strict_decode64(account_provider.seal(token))
+      payload = Base64.strict_decode64(account_provider.send(:seal, token))
       payload[-1] = payload[-1].next
 
       expect { account_provider.unseal(payload) }.to raise_error(CryptoError)
@@ -74,28 +74,28 @@ module Darrrr
 
     it "invalid sealed tokens errors" do
       # mess with the token
-      payload = Base64.strict_decode64(account_provider.seal(token))
+      payload = Base64.strict_decode64(account_provider.send(:seal, token))
       payload = payload[1..-1]
 
       expect { account_provider.unseal(payload) }.to raise_error(RecoveryTokenSerializationError)
     end
 
     it "validates countersigned tokens" do
-      sealed_token = Base64.strict_decode64(account_provider.seal(token))
+      sealed_token = Base64.strict_decode64(account_provider.send(:seal, token))
       countersigned_token = recovery_provider.countersign_token(sealed_token)
       expect(account_provider.validate_countersigned_recovery_token!(countersigned_token)).to_not be_nil
     end
 
     it "rejects countersigned tokens where the nested token has an invalid type" do
       token.token_object.version = 99999999
-      countersigned_token = recovery_provider.seal(raw_token(recovery_token: token))
+      countersigned_token = recovery_provider.send(:seal, raw_token(recovery_token: token))
       expect {
         account_provider.validate_countersigned_recovery_token!(countersigned_token)
       }.to raise_error(CountersignedTokenError, /Nested recovery token format error: Version field must be 0/)
     end
 
     it "rejects countersigned tokens with an invalid version number" do
-      countersigned_token = recovery_provider.seal(raw_token(recovery_token: token, version: 99999999))
+      countersigned_token = recovery_provider.send(:seal, raw_token(recovery_token: token, version: 99999999))
       expect {
         account_provider.validate_countersigned_recovery_token!(countersigned_token)
       }.to raise_error(CountersignedTokenError, /Version field must be 0/)
@@ -103,14 +103,14 @@ module Darrrr
 
     it "rejects countersigned tokens with the unknown issuers" do
       token.token_object.audience = "https://fooooobarrrr.com"
-      countersigned_token = recovery_provider.seal(raw_token(recovery_token: token))
+      countersigned_token = recovery_provider.send(:seal, raw_token(recovery_token: token))
       expect {
         account_provider.validate_countersigned_recovery_token!(countersigned_token)
       }.to raise_error(CountersignedTokenError, /Validate the the issuer field is present in the countersigned-token, and that it matches the audience field in the original token/)
     end
 
     it "rejects countersigned tokens when the recovery token issuer is not the same as the countersigned token audience" do
-      countersigned_token = recovery_provider.seal(raw_token(recovery_token: token, issuer: "https://fooooooo.com"))
+      countersigned_token = recovery_provider.send(:seal, raw_token(recovery_token: token, issuer: "https://fooooooo.com"))
       expect {
         account_provider.validate_countersigned_recovery_token!(countersigned_token)
       }.to raise_error(CountersignedTokenError, /Unknown recovery provider/)
@@ -118,24 +118,24 @@ module Darrrr
 
 
     it "rejects stale countersigned tokens" do
-      countersigned_token = recovery_provider.seal(raw_token(recovery_token: token, issued_time: (Time.new - CLOCK_SKEW - 1).iso8601))
+      countersigned_token = recovery_provider.send(:seal, raw_token(recovery_token: token, issued_time: (Time.new - CLOCK_SKEW - 1).iso8601))
       expect {
         account_provider.validate_countersigned_recovery_token!(countersigned_token)
       }.to raise_error(CountersignedTokenError, /Countersigned recovery token issued at time is too far in the past/)
 
-      countersigned_token = recovery_provider.seal(raw_token(recovery_token: token, issued_time: ""))
+      countersigned_token = recovery_provider.send(:seal, raw_token(recovery_token: token, issued_time: ""))
       expect {
         account_provider.validate_countersigned_recovery_token!(countersigned_token)
       }.to raise_error(CountersignedTokenError, /Invalid countersigned token issued time/)
 
-      countersigned_token = recovery_provider.seal(raw_token(recovery_token: token, issued_time: "steve"))
+      countersigned_token = recovery_provider.send(:seal, raw_token(recovery_token: token, issued_time: "steve"))
       expect {
         account_provider.validate_countersigned_recovery_token!(countersigned_token)
       }.to raise_error(CountersignedTokenError, /Invalid countersigned token issued time/)
     end
 
     it "rejects countersigned tokens with an invalid signature" do
-      countersigned_token = Base64.strict_decode64(recovery_provider.seal(raw_token(recovery_token: token)))
+      countersigned_token = Base64.strict_decode64(recovery_provider.send(:seal, raw_token(recovery_token: token)))
       countersigned_token[-1] = countersigned_token[-1].next
       countersigned_token = Base64.strict_encode64(countersigned_token)
 
@@ -145,7 +145,7 @@ module Darrrr
     end
 
     it "rejects invalid countersigned tokens" do
-      countersigned_token = recovery_provider.seal(raw_token(recovery_token: token))
+      countersigned_token = recovery_provider.send(:seal, raw_token(recovery_token: token))
       decoded = Base64.strict_decode64(countersigned_token)
       countersigned_token = Base64.strict_encode64(decoded[5..-1])
 
@@ -155,9 +155,9 @@ module Darrrr
     end
 
     it "rejects contersigned tokens where the nested token's signature is invalid" do
-      payload = Base64.strict_decode64(account_provider.seal(token))
+      payload = Base64.strict_decode64(account_provider.send(:seal, token))
       payload[-1] = payload[-1].next
-      countersigned_token = recovery_provider.seal(raw_token(data: payload))
+      countersigned_token = recovery_provider.send(:seal, raw_token(data: payload))
 
       expect {
         account_provider.validate_countersigned_recovery_token!(countersigned_token)
@@ -165,9 +165,9 @@ module Darrrr
     end
 
     it "rejects contersigned tokens where the nested token is invalid" do
-      payload = Base64.strict_decode64(account_provider.seal(token))
+      payload = Base64.strict_decode64(account_provider.send(:seal, token))
       payload = payload[1..-1].next
-      countersigned_token = recovery_provider.seal(raw_token(data: payload))
+      countersigned_token = recovery_provider.send(:seal, raw_token(data: payload))
 
       expect {
         account_provider.validate_countersigned_recovery_token!(countersigned_token)
@@ -178,7 +178,7 @@ module Darrrr
       garbage_data = EncryptedData.build("foo").to_binary_s
       garbage_data[-1] = garbage_data[-1].next
       token.data = garbage_data
-      payload = Base64.strict_decode64(account_provider.seal(token))
+      payload = Base64.strict_decode64(account_provider.send(:seal, token))
       countersigned_token = recovery_provider.seal(raw_token(data: payload))
 
       validated_token = account_provider.validate_countersigned_recovery_token!(countersigned_token)

--- a/spec/lib/darrrr/account_provider_spec.rb
+++ b/spec/lib/darrrr/account_provider_spec.rb
@@ -36,8 +36,8 @@ module Darrrr
 
     it "tokens can be sealed and unsealed when there are multiple unseal keys" do
       expect(account_provider).to receive(:unseal_keys).and_return(
-        [account_provider.tokensign_pubkeys_secp256r1[0], unused_unseal_key]
-      )
+        [account_provider.unseal_keys[0], unused_unseal_key]
+      ).at_least(:once)
       payload = Base64.strict_decode64(account_provider.seal(token))
       unsealed_token = account_provider.unseal(payload)
       expect(token.token_object).to eq(unsealed_token.token_object)
@@ -47,8 +47,9 @@ module Darrrr
     it "tokens can be sealed and unsealed when there are multiple unseal keys when ordered in reverse" do
       # Switch up the order just to make sure it works regardless of which comes first.
       expect(account_provider).to receive(:unseal_keys).and_return(
-        [unused_unseal_key, account_provider.tokensign_pubkeys_secp256r1[0]]
-      )
+        [unused_unseal_key, account_provider.unseal_keys[0]]
+      ).at_least(:once)
+
       payload = Base64.strict_decode64(account_provider.seal(token))
       unsealed_token = account_provider.unseal(payload)
       expect(token.token_object).to eq(unsealed_token.token_object)

--- a/spec/lib/darrrr/cryptors/default/encrypted_data_spec.rb
+++ b/spec/lib/darrrr/cryptors/default/encrypted_data_spec.rb
@@ -16,7 +16,7 @@ module Darrrr
       data.token_object.version = 100
       expect {
         EncryptedData.parse(data.to_binary_s)
-      }.to raise_error(ArgumentError)
+      }.to raise_error(TokenFormatError)
     end
 
     it "rejects tokens with an invalid auth_tag" do

--- a/spec/lib/darrrr/recovery_provider_spec.rb
+++ b/spec/lib/darrrr/recovery_provider_spec.rb
@@ -139,7 +139,7 @@ module Darrrr
 
     it "countersigned tokens can be unsealed when there are multiple unseal keys" do
       expect(recovery_provider).to receive(:unseal_keys).and_return(
-        [recovery_provider.countersign_pubkeys_secp256r1[0], unused_unseal_key]
+        [recovery_provider.unseal_keys[0], unused_unseal_key]
       )
       sealed_token = Base64.strict_decode64(account_provider.seal(token))
       countersigned_token = recovery_provider.countersign_token(sealed_token)
@@ -151,7 +151,7 @@ module Darrrr
     it "countersigned tokens can be unsealed when there are multiple unseal keys when the order is swapped" do
       # Switch up the order just to make sure it works regardless of which comes first.
       expect(recovery_provider).to receive(:unseal_keys).and_return(
-        [unused_unseal_key, recovery_provider.countersign_pubkeys_secp256r1[0]]
+        [unused_unseal_key, recovery_provider.unseal_keys[0]]
       )
       sealed_token = Base64.strict_decode64(account_provider.seal(token))
       countersigned_token = recovery_provider.countersign_token(sealed_token)

--- a/spec/lib/darrrr/recovery_token_spec.rb
+++ b/spec/lib/darrrr/recovery_token_spec.rb
@@ -6,7 +6,7 @@ module Darrrr
   describe RecoveryToken, vcr: { :cassette_name => "delegated_account_recovery/recovery_provider" } do
     let(:binding) { SecureRandom.hex }
     let(:recovery_provider) { example_account_provider }
-    let(:token) { AccountProvider.this.generate_recovery_token(data: "hai", audience: recovery_provider) }
+    let(:token) { AccountProvider.this.generate_recovery_token(data: "hai", audience: recovery_provider).first }
 
     it "can generate and parse a token" do
       parsed_token = RecoveryToken.parse(token.to_binary_s)

--- a/spec/lib/darrrr_spec.rb
+++ b/spec/lib/darrrr_spec.rb
@@ -64,8 +64,11 @@ describe Darrrr, vcr: { :cassette_name => "delegated_account_recovery/recovery_p
 
   it "passes context from high level operations to low level crypto calls when verifying/countersigning a token" do
     context = { foo: :bar }
+
     token, sealed_token = Darrrr.this_account_provider.generate_recovery_token(data: "foo", audience: Darrrr.this_recovery_provider)
     sealed_token = Base64.strict_decode64(sealed_token)
+
+    expect(Darrrr.this_account_provider).to receive(:unseal_keys).with(context).and_return(["bar"])
 
     expect(Darrrr.encryptor).to receive(:verify).with(anything, anything, anything, anything, context).and_return(true)
     Darrrr.this_recovery_provider.validate_recovery_token!(sealed_token, context)
@@ -80,6 +83,7 @@ describe Darrrr, vcr: { :cassette_name => "delegated_account_recovery/recovery_p
     sealed_token = Base64.strict_decode64(sealed_token)
     countersigned_token = Darrrr.this_recovery_provider.countersign_token(sealed_token, context)
 
+    expect(Darrrr.this_account_provider).to receive(:unseal_keys).with(context).and_return(["bar"])
     expect(Darrrr.encryptor).to receive(:verify).with(anything, anything, anything, anything, context).and_return(true).twice
     Darrrr.this_account_provider.validate_countersigned_recovery_token!(countersigned_token, context)
   end

--- a/spec/lib/darrrr_spec.rb
+++ b/spec/lib/darrrr_spec.rb
@@ -85,19 +85,19 @@ describe Darrrr, vcr: { :cassette_name => "delegated_account_recovery/recovery_p
           string.tr("A-Za-z", "N-ZA-Mn-za-m")
         end
 
-        def sign(serialized_token, key)
+        def sign(serialized_token, key, provider)
           "abc123"
         end
 
-        def verify(payload, signature, key)
+        def verify(payload, signature, key, provider)
           signature == "abc123"
         end
 
-        def decrypt(encrypted_data)
+        def decrypt(encrypted_data, provider)
           rot13(encrypted_data)
         end
 
-        def encrypt(data)
+        def encrypt(data, provider)
           rot13(data)
         end
       end

--- a/spec/lib/darrrr_spec.rb
+++ b/spec/lib/darrrr_spec.rb
@@ -45,6 +45,16 @@ describe Darrrr, vcr: { :cassette_name => "delegated_account_recovery/recovery_p
     end
   end
 
+  it "allows procs as values for tokensign_pubkeys_secp256r1" do
+    expect(Darrrr.this_account_provider.instance_variable_get(:@tokensign_pubkeys_secp256r1)).to be_a(Proc)
+    expect(Darrrr.this_account_provider.unseal_keys).to eq([ENV["ACCOUNT_PROVIDER_PUBLIC_KEY"]])
+  end
+
+  it "allows procs as values for countersign_pubkeys_secp256r1" do
+    expect(Darrrr.this_recovery_provider.instance_variable_get(:@countersign_pubkeys_secp256r1)).to be_a(Proc)
+    expect(Darrrr.this_recovery_provider.unseal_keys).to eq([ENV["RECOVERY_PROVIDER_PUBLIC_KEY"]])
+  end
+
   context "#account_provider_config" do
     it "returns a hash" do
       expect(Darrrr.account_provider_config).to be_kind_of(Hash)

--- a/spec/lib/darrrr_spec.rb
+++ b/spec/lib/darrrr_spec.rb
@@ -85,19 +85,19 @@ describe Darrrr, vcr: { :cassette_name => "delegated_account_recovery/recovery_p
           string.tr("A-Za-z", "N-ZA-Mn-za-m")
         end
 
-        def sign(serialized_token, key, provider)
+        def sign(serialized_token, key)
           "abc123"
         end
 
-        def verify(payload, signature, key, provider)
+        def verify(payload, signature, key)
           signature == "abc123"
         end
 
-        def decrypt(encrypted_data, provider)
+        def decrypt(encrypted_data)
           rot13(encrypted_data)
         end
 
-        def encrypt(data, provider)
+        def encrypt(data)
           rot13(data)
         end
       end

--- a/spec/lib/integration/recovery_provider_controller_spec.rb
+++ b/spec/lib/integration/recovery_provider_controller_spec.rb
@@ -8,15 +8,13 @@ describe "AccountProviderController", vcr: { cassette_name: "delegated_account_r
   end
 
   it "saves a token" do
-    token = example_account_provider.generate_recovery_token(data: "foo", audience: Darrrr::RecoveryProvider.this)
-    sealed_token = example_account_provider.seal(token)
+    token, sealed_token = example_account_provider.generate_recovery_token(data: "foo", audience: Darrrr::RecoveryProvider.this)
     post "/recovery-provider/save-token", token: sealed_token
     expect(last_response.header["location"]).to match("save-success")
   end
 
   it "rejects a bad token" do
-    token = example_account_provider.generate_recovery_token(data: "foo", audience: Darrrr::RecoveryProvider.this)
-    sealed_token = example_account_provider.seal(token)
+    token, sealed_token = example_account_provider.generate_recovery_token(data: "foo", audience: Darrrr::RecoveryProvider.this)
     sealed_token = sealed_token[0..-5]
     post "/recovery-provider/save-token", token: sealed_token
     expect(last_response.header["location"]).to match("save-failure")


### PR DESCRIPTION
Main changes:

* Custom encryptors are per (local) provider
* All crypto operations gained two params:
  * provider - the `AccountProvider` or `RecoveryProvider` instance performing the crypto.
  * context - arbitrary data that is passed in from higher level functions (e.g. `generate_recovery_token` and `generate_countersigned_token`.
* The public key config values now also accept a `proc` and the `provider` and `context` are the block arguments.
* `generate_recovery_token` now returns the token object and the "sealed" token as a single operation
  * as a result, the `seal` method is now private since `generate_recovery_token` is its only caller
* Cleanup the errors that could be raised to descend from a common parent
* Since `countersign_pubkeys_secp256r1` and `tokensign_pubkeys_secp256r1` can be arrays or `proc`s, make the method private. Use `unseal_keys(context)` to get this.
