### PR TITLE
Add argument to pass along `options` value to recovery/countersigned token creation

### DIFF
--- a/controllers/recovery_provider_controller.rb
+++ b/controllers/recovery_provider_controller.rb
@@ -28,7 +28,7 @@ class RecoveryProviderController < MainController
     token = Base64.strict_decode64(RecoveryToken.find_by_token_id(params[:token_id] || params[:id]).token_blob)
 
     account_provider = Darrrr::RecoveryToken.account_provider_issuer(token)
-    countersigned_recovery_token = Darrrr.this_recovery_provider.countersign_token(token)
+    countersigned_recovery_token = Darrrr.this_recovery_provider.countersign_token(token: token)
 
     audit("recovery initiated", Darrrr::RecoveryToken.parse(token).token_id.to_hex)
     notify("we've countersigned and sent a recovery token", account_provider)

--- a/lib/darrrr/account_provider.rb
+++ b/lib/darrrr/account_provider.rb
@@ -55,7 +55,7 @@ module Darrrr
     # context: arbitrary data passed on to underlying crypto operations
     #
     # returns a [RecoveryToken, b64 encoded sealed_token] tuple
-    def generate_recovery_token(data:, audience:, context: nil, options: nil)
+    def generate_recovery_token(data:, audience:, context: nil, options: 0)
       token = RecoveryToken.build(issuer: self, audience: audience, type: RECOVERY_TOKEN_TYPE, options: options)
       token.data = self.encryptor.encrypt(data, self, context)
 

--- a/lib/darrrr/account_provider.rb
+++ b/lib/darrrr/account_provider.rb
@@ -55,8 +55,8 @@ module Darrrr
     # context: arbitrary data passed on to underlying crypto operations
     #
     # returns a [RecoveryToken, b64 encoded sealed_token] tuple
-    def generate_recovery_token(data:, audience:, context: nil)
-      token = RecoveryToken.build(issuer: self, audience: audience, type: RECOVERY_TOKEN_TYPE)
+    def generate_recovery_token(data:, audience:, context: nil, options: nil)
+      token = RecoveryToken.build(issuer: self, audience: audience, type: RECOVERY_TOKEN_TYPE, options: options)
       token.data = self.encryptor.encrypt(data, self, context)
 
       [token, seal(token, context)]

--- a/lib/darrrr/account_provider.rb
+++ b/lib/darrrr/account_provider.rb
@@ -55,7 +55,7 @@ module Darrrr
     # context: arbitrary data passed on to underlying crypto operations
     #
     # returns a [RecoveryToken, b64 encoded sealed_token] tuple
-    def generate_recovery_token(data:, audience:, context: nil, options: 0)
+    def generate_recovery_token(data:, audience:, context: nil, options: nil)
       token = RecoveryToken.build(issuer: self, audience: audience, type: RECOVERY_TOKEN_TYPE, options: options)
       token.data = self.encryptor.encrypt(data, self, context)
 

--- a/lib/darrrr/account_provider.rb
+++ b/lib/darrrr/account_provider.rb
@@ -53,9 +53,10 @@ module Darrrr
     # data: value to encrypt in the token
     # provider: the recovery provider/audience of the token
     # context: arbitrary data passed on to underlying crypto operations
+    # options: the value to set for the options byte
     #
     # returns a [RecoveryToken, b64 encoded sealed_token] tuple
-    def generate_recovery_token(data:, audience:, context: nil, options: nil)
+    def generate_recovery_token(data:, audience:, context: nil, options: 0x00)
       token = RecoveryToken.build(issuer: self, audience: audience, type: RECOVERY_TOKEN_TYPE, options: options)
       token.data = self.encryptor.encrypt(data, self, context)
 

--- a/lib/darrrr/recovery_provider.rb
+++ b/lib/darrrr/recovery_provider.rb
@@ -66,10 +66,13 @@ module Darrrr
     # data structure is identical to the structure it's wrapping in format.
     #
     # token: the to_binary_s or binary representation of the recovery token
+    # context: an arbitrary object that is passed to lower level crypto operations
+    # options: the value to set in the options byte field of the recovery
+    #   token (defaults to 0x00)
     #
     # returns a Base64 encoded representation of the countersigned token
     # and the signature over the token.
-    def countersign_token(token, context = nil)
+    def countersign_token(token:, context: nil, options: 0x00)
       begin
         account_provider = RecoveryToken.account_provider_issuer(token)
       rescue RecoveryTokenSerializationError, UnknownProviderError
@@ -79,7 +82,8 @@ module Darrrr
       counter_recovery_token = RecoveryToken.build(
         issuer: self,
         audience: account_provider,
-        type: COUNTERSIGNED_RECOVERY_TOKEN_TYPE
+        type: COUNTERSIGNED_RECOVERY_TOKEN_TYPE,
+        options: options,
       )
 
       counter_recovery_token.data = token

--- a/lib/darrrr/recovery_token.rb
+++ b/lib/darrrr/recovery_token.rb
@@ -40,12 +40,12 @@ module Darrrr
       # token.
       #
       # returns a RecoveryToken.
-      def build(issuer:, audience:, type:)
+      def build(issuer:, audience:, type:, options: nil)
         token = RecoveryTokenWriter.new.tap do |token|
           token.token_id = token_id
           token.issuer = issuer.origin
           token.issued_time = Time.now.utc.iso8601
-          token.options = 0 # when the token-status endpoint is implemented, change this to 1
+          token.options = options || 0
           token.audience = audience.origin
           token.version = Darrrr::PROTOCOL_VERSION
           token.token_type = type

--- a/lib/darrrr/recovery_token.rb
+++ b/lib/darrrr/recovery_token.rb
@@ -40,12 +40,12 @@ module Darrrr
       # token.
       #
       # returns a RecoveryToken.
-      def build(issuer:, audience:, type:, options: 0)
+      def build(issuer:, audience:, type:, options: nil)
         token = RecoveryTokenWriter.new.tap do |token|
           token.token_id = token_id
           token.issuer = issuer.origin
           token.issued_time = Time.now.utc.iso8601
-          token.options = options
+          token.options = options || 0
           token.audience = audience.origin
           token.version = Darrrr::PROTOCOL_VERSION
           token.token_type = type

--- a/lib/darrrr/recovery_token.rb
+++ b/lib/darrrr/recovery_token.rb
@@ -40,12 +40,12 @@ module Darrrr
       # token.
       #
       # returns a RecoveryToken.
-      def build(issuer:, audience:, type:, options: nil)
+      def build(issuer:, audience:, type:, options: 0)
         token = RecoveryTokenWriter.new.tap do |token|
           token.token_id = token_id
           token.issuer = issuer.origin
           token.issued_time = Time.now.utc.iso8601
-          token.options = options || 0
+          token.options = options
           token.audience = audience.origin
           token.version = Darrrr::PROTOCOL_VERSION
           token.token_type = type

--- a/lib/darrrr/recovery_token.rb
+++ b/lib/darrrr/recovery_token.rb
@@ -35,17 +35,17 @@ module Darrrr
 
     class << self
       # data: the value that will be encrypted by EncryptedData.
-      # recovery_provider: the provider for which we are building the token.
-      # binding_data: a value retrieved from the recovery provider for this
-      # token.
+      # audience: the provider for which we are building the token.
+      # type: Either 0 (recovery token) or 1 (countersigned recovery token)
+      # options: the value to set for the options byte
       #
       # returns a RecoveryToken.
-      def build(issuer:, audience:, type:, options: nil)
+      def build(issuer:, audience:, type:, options: 0x00)
         token = RecoveryTokenWriter.new.tap do |token|
           token.token_id = token_id
           token.issuer = issuer.origin
           token.issued_time = Time.now.utc.iso8601
-          token.options = options || 0
+          token.options = options
           token.audience = audience.origin
           token.version = Darrrr::PROTOCOL_VERSION
           token.token_type = type

--- a/spec/lib/darrrr/account_provider_spec.rb
+++ b/spec/lib/darrrr/account_provider_spec.rb
@@ -82,7 +82,7 @@ module Darrrr
 
     it "validates countersigned tokens" do
       sealed_token = Base64.strict_decode64(account_provider.send(:seal, token))
-      countersigned_token = recovery_provider.countersign_token(sealed_token)
+      countersigned_token = recovery_provider.countersign_token(token: sealed_token)
       expect(account_provider.validate_countersigned_recovery_token!(countersigned_token)).to_not be_nil
     end
 

--- a/spec/lib/darrrr/recovery_provider_spec.rb
+++ b/spec/lib/darrrr/recovery_provider_spec.rb
@@ -131,10 +131,17 @@ module Darrrr
 
     it "countersigns tokens" do
       sealed_token = Base64.strict_decode64(account_provider.send(:seal, token))
-      countersigned_token = recovery_provider.countersign_token(sealed_token)
+      countersigned_token = recovery_provider.countersign_token(token: sealed_token)
       raw_counter_token = recovery_provider.unseal(Base64.strict_decode64(countersigned_token))
       expect(sealed_token).to eq(raw_counter_token.data.to_binary_s)
       expect(account_provider.unseal(raw_counter_token.data.to_binary_s)).to_not be_nil
+    end
+
+    it "sets the option value when countersigning tokens" do
+      sealed_token = Base64.strict_decode64(account_provider.send(:seal, token))
+      countersigned_token = recovery_provider.countersign_token(token: sealed_token, options: 0x02)
+      raw_counter_token = recovery_provider.unseal(Base64.strict_decode64(countersigned_token))
+      expect(raw_counter_token.options).to eq(0x02)
     end
 
     it "countersigned tokens can be unsealed when there are multiple unseal keys" do
@@ -142,7 +149,7 @@ module Darrrr
         [recovery_provider.unseal_keys[0], unused_unseal_key]
       )
       sealed_token = Base64.strict_decode64(account_provider.send(:seal, token))
-      countersigned_token = recovery_provider.countersign_token(sealed_token)
+      countersigned_token = recovery_provider.countersign_token(token: sealed_token)
       raw_counter_token = recovery_provider.unseal(Base64.strict_decode64(countersigned_token))
       expect(sealed_token).to eq(raw_counter_token.data.to_binary_s)
       expect(account_provider.unseal(sealed_token)).to_not be_nil
@@ -154,7 +161,7 @@ module Darrrr
         [unused_unseal_key, recovery_provider.unseal_keys[0]]
       )
       sealed_token = Base64.strict_decode64(account_provider.send(:seal, token))
-      countersigned_token = recovery_provider.countersign_token(sealed_token)
+      countersigned_token = recovery_provider.countersign_token(token: sealed_token)
       raw_counter_token = recovery_provider.unseal(Base64.strict_decode64(countersigned_token))
       expect(sealed_token).to eq(raw_counter_token.data.to_binary_s)
       expect(account_provider.unseal(sealed_token)).to_not be_nil
@@ -163,7 +170,7 @@ module Darrrr
     it "doesn't countersign tokens it can't parse" do
       sealed_token = Base64.strict_decode64(account_provider.send(:seal, token)).reverse
       expect {
-        recovery_provider.countersign_token(sealed_token)
+        recovery_provider.countersign_token(token: sealed_token)
       }.to raise_error(TokenFormatError)
     end
 
@@ -172,7 +179,7 @@ module Darrrr
         [unused_unseal_key]
       )
       sealed_token = Base64.strict_decode64(account_provider.send(:seal, token))
-      countersigned_token = recovery_provider.countersign_token(sealed_token)
+      countersigned_token = recovery_provider.countersign_token(token: sealed_token)
       expect {
         recovery_provider.unseal(Base64.strict_decode64(countersigned_token))
       }.to raise_error(CryptoError)

--- a/spec/lib/darrrr_spec.rb
+++ b/spec/lib/darrrr_spec.rb
@@ -74,14 +74,14 @@ describe Darrrr, vcr: { :cassette_name => "delegated_account_recovery/recovery_p
     Darrrr.this_recovery_provider.validate_recovery_token!(sealed_token, context)
 
     expect(Darrrr.this_recovery_provider.encryptor).to receive(:sign).with(anything, anything, anything, context).and_return("signed")
-    Darrrr.this_recovery_provider.countersign_token(sealed_token, context)
+    Darrrr.this_recovery_provider.countersign_token(token: sealed_token, context: context)
   end
 
   it "passes context from high level operations to low level crypto calls when verifying/countersigning a token" do
     context = { foo: :bar }
     token, sealed_token = Darrrr.this_account_provider.generate_recovery_token(data: "foo", audience: Darrrr.this_recovery_provider)
     sealed_token = Base64.strict_decode64(sealed_token)
-    countersigned_token = Darrrr.this_recovery_provider.countersign_token(sealed_token, context)
+    countersigned_token = Darrrr.this_recovery_provider.countersign_token(token: sealed_token, context: context)
 
     expect(Darrrr.this_account_provider).to receive(:unseal_keys).with(context).and_return(["bar"])
     expect(Darrrr.this_account_provider.encryptor).to receive(:verify).with(anything, anything, anything, anything, context).and_return(true)
@@ -160,7 +160,7 @@ describe Darrrr, vcr: { :cassette_name => "delegated_account_recovery/recovery_p
         sealed_token = Base64.strict_decode64(sealed_token)
         recovery_provider.validate_recovery_token!(sealed_token)
 
-        countersigned_token = recovery_provider.countersign_token(sealed_token)
+        countersigned_token = recovery_provider.countersign_token(token: sealed_token)
         account_provider.validate_countersigned_recovery_token!(countersigned_token)
 
         unsealed_countersigned_token = recovery_provider.unseal(Base64.strict_decode64(countersigned_token))
@@ -183,7 +183,7 @@ describe Darrrr, vcr: { :cassette_name => "delegated_account_recovery/recovery_p
           sealed_token = Base64.strict_decode64(sealed_token)
           recovery_provider.validate_recovery_token!(sealed_token)
 
-          countersigned_token = recovery_provider.countersign_token(sealed_token)
+          countersigned_token = recovery_provider.countersign_token(token: sealed_token)
           account_provider.validate_countersigned_recovery_token!(countersigned_token)
 
           unsealed_countersigned_token = recovery_provider.unseal(Base64.strict_decode64(countersigned_token))

--- a/spec/lib/darrrr_spec.rb
+++ b/spec/lib/darrrr_spec.rb
@@ -89,6 +89,10 @@ describe Darrrr, vcr: { :cassette_name => "delegated_account_recovery/recovery_p
     Darrrr.this_account_provider.validate_countersigned_recovery_token!(countersigned_token, context)
   end
 
+  it "allows you to set the options value for a token" do
+    token, _ = Darrrr.this_account_provider.generate_recovery_token(data: "foo", audience: Darrrr.this_recovery_provider, options: 0x02)
+    expect(token.options).to eq(0x02)
+  end
 
   context "#account_provider_config" do
     it "returns a hash" do


### PR DESCRIPTION
Defaults to `0x00`.

Also, `countersign_token` takes kwargs instead of positional args now.