### PR TITLE
make the faraday callback a global config

### DIFF
--- a/lib/darrrr.rb
+++ b/lib/darrrr.rb
@@ -58,13 +58,13 @@ module Darrrr
   class << self
     # recovery provider data is only loaded (and cached) upon use.
     attr_accessor :recovery_providers, :account_providers, :cache, :allow_unsafe_urls,
-      :privacy_policy, :icon_152px, :authority
+      :privacy_policy, :icon_152px, :authority, :faraday_config_callback
 
     # Find and load remote recovery provider configuration data.
     #
     # provider_origin: the origin that contains the config data in a well-known
     # location.
-    def recovery_provider(provider_origin, &block)
+    def recovery_provider(provider_origin)
       unless self.recovery_providers
         raise "No recovery providers configured"
       end
@@ -72,11 +72,7 @@ module Darrrr
       if provider_origin == this_recovery_provider&.origin
         this_recovery_provider
       elsif self.recovery_providers.include?(provider_origin)
-        RecoveryProvider.new(provider_origin).tap { |provider|
-          if block_given?
-            yield provider
-          end
-        }.load
+        RecoveryProvider.new(provider_origin).load
       else
         raise UnknownProviderError, "Unknown recovery provider: #{provider_origin}"
       end
@@ -101,11 +97,7 @@ module Darrrr
       if provider_origin == this_account_provider&.origin
         this_account_provider
       elsif self.account_providers.include?(provider_origin)
-        AccountProvider.new(provider_origin).tap { |provider|
-          if block_given?
-            yield provider
-          end
-        }.load
+        AccountProvider.new(provider_origin).load
       else
         raise UnknownProviderError, "Unknown account provider: #{provider_origin}"
       end

--- a/lib/darrrr/provider.rb
+++ b/lib/darrrr/provider.rb
@@ -9,7 +9,6 @@ module Darrrr
 
     def self.included(base)
       base.instance_eval do
-        attr_accessor :faraday_config_callback
         # this represents the account/recovery provider on this web app
         class << self
           attr_accessor :this
@@ -77,8 +76,8 @@ module Darrrr
 
     private def faraday
       Faraday.new do |f|
-        if @faraday_config_callback
-          @faraday_config_callback.call(f)
+        if Darrrr.faraday_config_callback
+          Darrrr.faraday_config_callback.call(f)
         else
           f.adapter(Faraday.default_adapter)
         end

--- a/spec/lib/darrrr/account_provider_spec.rb
+++ b/spec/lib/darrrr/account_provider_spec.rb
@@ -28,36 +28,22 @@ module Darrrr
     end
 
     it "provides extra options for faraday" do
-      account_provider.faraday_config_callback = lambda do |faraday|
-        faraday.headers["Accept-Encoding"] = :foo
-        faraday.adapter(:typhoeus)
+      Darrrr.faraday_config_callback = lambda do |faraday|
+        faraday.headers["Accept-Encoding"] = "foo"
+        faraday.adapter(Faraday.default_adapter)
       end
+      account_provider = example_account_provider
 
       # assert extra header
       account_provider_faraday = account_provider.send(:faraday)
-      expect(account_provider_faraday.headers).to include("Accept-Encoding" => :foo)
+      expect(account_provider_faraday.headers).to include("Accept-Encoding" => "foo")
 
       # assert handler is property set
       handler = JSON.parse(account_provider_faraday.to_json)["builder"]["handlers"]
       expect(handler).to_not be_nil
       handler_name = handler.first["name"]
       expect(handler_name).to_not be_nil
-      expect(handler_name).to eq("Faraday::Adapter::Typhoeus")
-    end
-
-    it "allows you to configure the recovery provider during retrieval" do
-      account_provider = Darrrr.account_provider("https://example-provider.org") do |provider|
-        provider.faraday_config_callback = lambda do |faraday|
-          faraday.adapter(Faraday.default_adapter)
-          faraday.headers["Accept-Encoding"] = "foo"
-        end
-      end
-
-      expect(account_provider).to be_kind_of(Darrrr::AccountProvider)
-
-      # assert extra header
-      account_provider_faraday = account_provider.send(:faraday)
-      expect(account_provider_faraday.headers).to include("Accept-Encoding" => "foo")
+      expect(handler_name).to eq("Faraday::Adapter::NetHttp")
     end
 
     it "tokens can be sealed and unsealed" do

--- a/spec/lib/darrrr/recovery_provider_spec.rb
+++ b/spec/lib/darrrr/recovery_provider_spec.rb
@@ -45,21 +45,22 @@ module Darrrr
     end
 
     it "provides extra options for faraday" do
-      recovery_provider.faraday_config_callback = lambda do |faraday|
-        faraday.headers["Accept-Encoding"] = :foo
-        faraday.adapter(:typhoeus)
+      Darrrr.faraday_config_callback = lambda do |faraday|
+        faraday.headers["Accept-Encoding"] = "foo"
+        faraday.adapter(Faraday.default_adapter)
       end
+      recovery_provider = example_recovery_provider
 
       # assert extra header
       recovery_provider_faraday = recovery_provider.send(:faraday)
-      expect(recovery_provider_faraday.headers).to include("Accept-Encoding" => :foo)
+      expect(recovery_provider_faraday.headers).to include("Accept-Encoding" => "foo")
 
       # assert handler is property set
       handler = JSON.parse(recovery_provider_faraday.to_json)["builder"]["handlers"]
       expect(handler).to_not be_nil
       handler_name = handler.first["name"]
       expect(handler_name).to_not be_nil
-      expect(handler_name).to eq("Faraday::Adapter::Typhoeus")
+      expect(handler_name).to eq("Faraday::Adapter::NetHttp")
     end
 
     it "does not accept in incomplete config" do

--- a/spec/lib/darrrr_spec.rb
+++ b/spec/lib/darrrr_spec.rb
@@ -15,13 +15,11 @@ describe Darrrr, vcr: { :cassette_name => "delegated_account_recovery/recovery_p
     end
 
     it "allows you to configure the recovery provider during retrieval" do
-      recovery_provider = Darrrr.recovery_provider("https://example-provider.org") do |provider|
-        provider.faraday_config_callback = lambda do |faraday|
-          faraday.adapter(Faraday.default_adapter)
-          faraday.headers["Accept-Encoding"] = "foo"
-        end
+      Darrrr.faraday_config_callback = lambda do |faraday|
+        faraday.adapter(Faraday.default_adapter)
+        faraday.headers["Accept-Encoding"] = "foo"
       end
-
+      recovery_provider = Darrrr.recovery_provider("https://example-provider.org")
       expect(recovery_provider).to be_kind_of(Darrrr::RecoveryProvider)
 
       # assert extra header

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,6 +68,10 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:truncation)
   end
 
+  config.before(:each) do
+    Darrrr.faraday_config_callback = nil
+  end
+
   config.around(:each) do |example|
     DatabaseCleaner.cleaning do
       example.run


### PR DESCRIPTION
#15 made faraday configurable per retrieval which isn't exactly convenient. This makes the Faraday connection settings global. Ideally, per-provider would work, but this works for now.