### PR TITLE
Use a constant for the gem version instead of a string, bump to 0.1.6

### DIFF
--- a/darrrr.gemspec
+++ b/darrrr.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name    = "darrrr"
-  gem.version = "0.1.5"
+  gem.version = Darrrr::VERSION
   gem.licenses = ["MIT"]
 
   gem.summary = "Client library for the Delegated Recovery spec"

--- a/darrrr.gemspec
+++ b/darrrr.gemspec
@@ -1,6 +1,8 @@
 # coding: utf-8
 # frozen_string_literal: true
 
+require_relative "lib/darrrr/version"
+
 Gem::Specification.new do |gem|
   gem.name    = "darrrr"
   gem.version = Darrrr::VERSION
@@ -12,12 +14,8 @@ Gem::Specification.new do |gem|
   gem.authors  = ["Neil Matatall"]
   gem.email    = "opensource+darrrr@github.com"
   gem.homepage = "http://github.com/github/darrrr"
-
-  gem.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
-  gem.bindir        = "exe"
   gem.require_paths = ["lib"]
+  gem.files = Dir["Rakefile", "{lib}/**/*", "README*", "LICENSE*"] & `git ls-files -z`.split("\0")
 
   gem.add_dependency("rake")
   if RUBY_VERSION > "2.6"
@@ -27,6 +25,4 @@ Gem::Specification.new do |gem|
   end
   gem.add_dependency("faraday")
   gem.add_dependency("addressable")
-
-  gem.files = Dir["Rakefile", "{lib}/**/*", "README*", "LICENSE*"] & `git ls-files -z`.split("\0")
 end

--- a/lib/darrrr.rb
+++ b/lib/darrrr.rb
@@ -19,7 +19,6 @@ require_relative "darrrr/cryptors/default/encrypted_data"
 require_relative "darrrr/cryptors/default/encrypted_data_io"
 
 module Darrrr
-  VERSION = "0.1.6"
   class DelegatedRecoveryError < StandardError; end
   # Represents a binary serialization error
   class RecoveryTokenSerializationError < DelegatedRecoveryError; end

--- a/lib/darrrr.rb
+++ b/lib/darrrr.rb
@@ -19,6 +19,7 @@ require_relative "darrrr/cryptors/default/encrypted_data"
 require_relative "darrrr/cryptors/default/encrypted_data_io"
 
 module Darrrr
+  VERSION = "0.1.6"
   class DelegatedRecoveryError < StandardError; end
   # Represents a binary serialization error
   class RecoveryTokenSerializationError < DelegatedRecoveryError; end

--- a/lib/darrrr/version.rb
+++ b/lib/darrrr/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Darrrr
+  VERSION = "0.1.6"
+end


### PR DESCRIPTION
This is a best practice, allowing tooling to access version numbers easily. 

The version bump includes the fix for ruby 2.7+